### PR TITLE
Do not allow usage of privileged application tags

### DIFF
--- a/.changeset/rare-tips-appear.md
+++ b/.changeset/rare-tips-appear.md
@@ -1,0 +1,5 @@
+---
+'@hoprnet/uhttp-lib': patch
+---
+
+Fix application tag choices to not use privileged ports

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -48,7 +48,8 @@ const log = RoutingUtils.logger(['uhttp-lib']);
 
 // message tag - more like port since we tag all our messages the same
 // 0xffff reserved for Availability Monitor
-const ApplicationTag = Math.floor(Math.random() * 0xfffe);
+// 0x3fff reserved for privileged applications
+const ApplicationTag = Math.floor(Math.random() * (0xffff - 0x0400) + 0x0400);
 
 /**
  * Global defaults.

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -48,7 +48,7 @@ const log = RoutingUtils.logger(['uhttp-lib']);
 
 // message tag - more like port since we tag all our messages the same
 // 0xffff reserved for Availability Monitor
-// 0x3fff reserved for privileged applications
+// 0x0000 to 0x3fff reserved for privileged applications
 const ApplicationTag = Math.floor(Math.random() * (0xffff - 0x0400) + 0x0400);
 
 /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Implemented a fix to prevent applications from using privileged ports, enhancing security and stability.
	- Updated the range for message tagging to ensure better categorization of application types.

- **Bug Fixes**
	- Adjusted the logic for generating application tags to avoid conflicts with reserved ports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->